### PR TITLE
Include annotation value in error log message

### DIFF
--- a/pkg/controllers/ingress_controller.go
+++ b/pkg/controllers/ingress_controller.go
@@ -120,7 +120,7 @@ func (r *IngressReconciler) calculateIngressWeight(ingress netv1.Ingress) (uint,
 	backendPercentage = float64(backendPercentage) / float64(100)
 	userDesiredWeight, err := strconv.ParseFloat(ingress.Annotations[r.annotationKey("traffic-weight")], 64)
 	if err != nil {
-		return 0, fmt.Errorf("Cannot parse annotation %v", r.annotationKey("traffic-weight"))
+		return 0, fmt.Errorf("Cannot parse annotation %v with value '%v'", r.annotationKey("traffic-weight"), ingress.Annotations[r.annotationKey("traffic-weight")])
 	}
 	if userDesiredWeight < 0 {
 		return 0, fmt.Errorf("Cannot handle negative traffic weights")


### PR DESCRIPTION
Context
-------

It is helpful to have the annotation value in the error message so you
don't need to check ingress by ingress what happened, as most likely
the problem is that the value provided is not a number
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>