### PR TITLE
Prevent changing dnsEndpoint name and namespace attributes in createOrUpdate

### DIFF
--- a/pkg/controllers/ingress_controller.go
+++ b/pkg/controllers/ingress_controller.go
@@ -175,8 +175,6 @@ func (r *IngressReconciler) newDnsEndpoint(ctx context.Context, dnsEndpoint *ext
 
 	setOwnerRef(dnsEndpoint, &ingress)
 
-	dnsEndpoint.Name = ingress.ObjectMeta.Name
-	dnsEndpoint.Namespace = ingress.ObjectMeta.Namespace
 	desiredWeight = uint(trafficweight.Store.DesiredWeight)
 	if r.isIngressWeighted(ingress) {
 		desiredWeight, err = r.calculateIngressWeight(ingress)

--- a/pkg/controllers/ingress_controller_test.go
+++ b/pkg/controllers/ingress_controller_test.go
@@ -130,7 +130,12 @@ func TestIngressController(t *testing.T) {
 	}
 
 	t.Run("Should forge DNS Endpoints", func(t *testing.T) {
-		forged := &externaldnsk8siov1alpha1.DNSEndpoint{}
+		forged := &externaldnsk8siov1alpha1.DNSEndpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "foo",
+			},
+		}
 		reconciler.newDnsEndpoint(context.Background(), forged, ing)
 		assert.Equal(t, expected, *forged)
 	})
@@ -194,7 +199,12 @@ func TestIngressController(t *testing.T) {
 
 	t.Run("if we dont set --aws-health-check-id ingress shouldnt have health property", func(t *testing.T) {
 		trafficweight.Store.AWSHealthCheckID = ""
-		forged := &externaldnsk8siov1alpha1.DNSEndpoint{}
+		forged := &externaldnsk8siov1alpha1.DNSEndpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "foo",
+			},
+		}
 		reconciler.newDnsEndpoint(context.Background(), forged, ing)
 		assert.Equal(t, expected, *forged)
 	})
@@ -229,7 +239,12 @@ func TestIngressController(t *testing.T) {
 			},
 		}
 
-		forged := &externaldnsk8siov1alpha1.DNSEndpoint{}
+		forged := &externaldnsk8siov1alpha1.DNSEndpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "foo",
+			},
+		}
 		reconciler.newDnsEndpoint(context.Background(), forged, ing)
 		assert.Equal(t, expected, *forged)
 		ing.Spec.Rules = oldRules


### PR DESCRIPTION
This is not permitted by controllerRuntime and should not be performed
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Refactor DNS name extraction (#13)
</summary>
Goal
---

Ease the implementation of CRD based multi-ingress controller traffic routing
</details>
<details>
<summary>
Add integration test (#16)
</summary>
Goal
---

Ensure that the chart provides enough privileges for the controller to work
</details>
<details>
<summary>
Add fine-grain ingress DNS control through CRD (#14)
</summary>
Context
---

Handling usual cluster operations, we often come to operate higher risk changes like bumping ingress controller
versions, changing the underneath ingress service type (for example moving from an AWS ELB to an AWS NLB).

Doing so, the safest way would be to be able to provision a new ingress controller and progressively migrating traffic
to the new instance.

Problems
---

Currently, traffic controller reads the host and load balancer reference using
the ingress status.

This prevents from being able to handle and control weighted records across the different ingress controllers.

Goal
---

Enable fine-grained routing between various ingress controllers in the same cluster.

Unblocked use-cases
---

- Progressively change and test the ingress infrastructure (load balancer, ...) and versions
- Allow sharding ingress controllers at the DNS level
</details>
</details>
</details>