### PR TITLE
Refactor DNS name extraction

### DIFF
--- a/pkg/controllers/ingress_controller.go
+++ b/pkg/controllers/ingress_controller.go
@@ -89,6 +89,14 @@ func (r *IngressReconciler) ingressAnnotationMatchFilter(ingress netv1.Ingress) 
 	return r.ingressHasAnnotationKeyValue(ingress, r.AnnotationFilter.key, r.AnnotationFilter.value)
 }
 
+func (r *IngressReconciler) listFilteredIngressHosts(ingress *netv1.Ingress) []string {
+	hosts := []string{}
+	for _, rule := range r.filterIngressRulesByHost(ingress.Spec.Rules) {
+		hosts = append(hosts, rule.Host)
+	}
+	return hosts
+}
+
 func (r *IngressReconciler) filterIngressRulesByHost(rules []netv1.IngressRule) []netv1.IngressRule {
 	rulesToBind := []netv1.IngressRule{}
 	for _, rule := range rules {
@@ -192,18 +200,24 @@ func (r *IngressReconciler) newDnsEndpoint(ctx context.Context, dnsEndpoint *ext
 		desiredWeight = 0
 	}
 	dnsEndpoint.Spec = externaldnsk8siov1alpha1.DNSEndpointSpec{Endpoints: []*externaldnsk8siov1alpha1.Endpoint{}}
-	for _, rule := range r.filterIngressRulesByHost(ingress.Spec.Rules) {
 
-		ep := &externaldnsk8siov1alpha1.Endpoint{
-			DNSName:       rule.Host,
-			RecordType:    "CNAME",
-			SetIdentifier: r.ClusterName,
+	dnsNames := r.listFilteredIngressHosts(&ingress)
+
+	if len(ingress.Status.LoadBalancer.Ingress) > 0 {
+		for _, dnsName := range dnsNames {
+
+			ep := &externaldnsk8siov1alpha1.Endpoint{
+				DNSName:       dnsName,
+				RecordType:    "CNAME",
+				SetIdentifier: r.ClusterName,
+			}
+			r.addIngressTargetsToEndpoint(ep, ingress)
+
+			setEndpointProviderSpecificProperty(ep, WeightProperty, strconv.FormatUint(uint64(desiredWeight), 10))
+
+			setGlobalHealthCheckID(ep)
+			dnsEndpoint.Spec.Endpoints = append(dnsEndpoint.Spec.Endpoints, ep)
 		}
-		r.addIngressTargetsToEndpoint(ep, ingress)
-
-		setEndpointProviderSpecificProperty(ep, WeightProperty, strconv.FormatUint(uint64(desiredWeight), 10))
-		setGlobalHealthCheckID(ep)
-		dnsEndpoint.Spec.Endpoints = append(dnsEndpoint.Spec.Endpoints, ep)
 	}
 }
 

--- a/pkg/controllers/ingress_controller_test.go
+++ b/pkg/controllers/ingress_controller_test.go
@@ -510,3 +510,22 @@ func TestEndpointsHasPods(t *testing.T) {
 
 	assert.False(t, r.endpointsHasPods(MockEndpoints(WithObjectFinalizers[*v1.Endpoints]("test.adevinta.com"), WithObjectDeletionTimestamp[*v1.Endpoints](metav1.Now()))))
 }
+
+func TestListFilteredIngressHosts(t *testing.T) {
+	r := IngressReconciler{
+		BindingDomain: "example.com",
+	}
+	assert.ElementsMatch(
+		t,
+		[]string{"host1.example.com", "example.com"},
+		r.listFilteredIngressHosts(
+			MockIngress(
+				IngressWithRules(
+					NewRule(RuleWithHost("host1.example.com")),
+					NewRule(RuleWithHost("example.com")),
+					NewRule(RuleWithHost("adevinta.com")),
+				),
+			),
+		),
+	)
+}


### PR DESCRIPTION
Goal
---

Ease the implementation of CRD based multi-ingress controller traffic routing
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add integration test (#16)
</summary>
Goal
---

Ensure that the chart provides enough privileges for the controller to work
</details>
<details>
<summary>
Add fine-grain ingress DNS control through CRD (#14)
</summary>
Context
---

Handling usual cluster operations, we often come to operate higher risk changes like bumping ingress controller
versions, changing the underneath ingress service type (for example moving from an AWS ELB to an AWS NLB).

Doing so, the safest way would be to be able to provision a new ingress controller and progressively migrating traffic
to the new instance.

Problems
---

Currently, traffic controller reads the host and load balancer reference using
the ingress status.

This prevents from being able to handle and control weighted records across the different ingress controllers.

Goal
---

Enable fine-grained routing between various ingress controllers in the same cluster.

Unblocked use-cases
---

- Progressively change and test the ingress infrastructure (load balancer, ...) and versions
- Allow sharding ingress controllers at the DNS level
</details>
</details>
</details>