### PR TITLE
fix: dynamodb cloudformation was wrong

### DIFF
--- a/cfn/k8s-traffic-controller/templates/dynamodb.yaml
+++ b/cfn/k8s-traffic-controller/templates/dynamodb.yaml
@@ -2,24 +2,15 @@ Resources:
     DDBTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: "k8s-traffic-controller",
+        TableName: k8s-traffic-controller
         AttributeDefinitions:
           -
             AttributeName: "ClusterName"
             AttributeType: "S"
-          -
-            AttributeName: "CurrentWeight"
-            AttributeType: "N"
-          -
-            AttributeName: "DesiredWeight"
-            AttributeType: "N"
         KeySchema:
           -
             AttributeName: "ClusterName"
             KeyType: "HASH"
-          -
-            AttributeName: "ClusterName"
-            KeyType: "RANGE"
         ProvisionedThroughput:
           ReadCapacityUnits: 5
           WriteCapacityUnits: 5

--- a/cmd/traffic-controller/main_test.go
+++ b/cmd/traffic-controller/main_test.go
@@ -107,7 +107,7 @@ func TestTrafficControllerController(t *testing.T) {
 	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
 	require.NoError(t, err)
 
-	installCRD(ctx, t, k8sClient, "https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/docs/contributing/crd-source/crd-manifest.yaml")
+	installCRD(ctx, t, k8sClient, "https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/config/crd/standard/dnsendpoints.externaldns.k8s.io.yaml")
 	installControllerChart(ctx, t, k8sClient, "--set", "devMode=true")
 	deleteControllerDeployment(t, k8sClient)
 


### PR DESCRIPTION
  - Attributes listed needs to be used in the keyschema
  - we don't define a sort key.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
chore: update reference to dnsendpoint CRD (#19)
</summary>

</details>
</details>
</details>