### PR TITLE
[need #18] chore: update reference to dnsendpoint CRD

### DIFF
--- a/cmd/traffic-controller/main_test.go
+++ b/cmd/traffic-controller/main_test.go
@@ -107,7 +107,7 @@ func TestTrafficControllerController(t *testing.T) {
 	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
 	require.NoError(t, err)
 
-	installCRD(ctx, t, k8sClient, "https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/docs/contributing/crd-source/crd-manifest.yaml")
+	installCRD(ctx, t, k8sClient, "https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/config/crd/standard/dnsendpoints.externaldns.k8s.io.yaml")
 	installControllerChart(ctx, t, k8sClient, "--set", "devMode=true")
 	deleteControllerDeployment(t, k8sClient)
 


### PR DESCRIPTION

<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
fix: dynamodb cloudformation was wrong (#18)
</summary>
  - Attributes listed needs to be used in the keyschema
  - we don't define a sort key.
</details>
</details>
</details>